### PR TITLE
Updates to get close to release 1

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,27 @@
+Copyright (c) 2015, Broad Institute, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name Broad Institute, Inc. nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -8,12 +8,16 @@ qualys_agent::cmd_max_timeout: 1800
 qualys_agent::cmd_stdout_size: 1024
 qualys_agent::conf_dir: /etc/qualys/cloud-agent
 qualys_agent::customer_id: ~
+qualys_agent::hostid_path: /etc/qualys/hostid
+qualys_agent::hostid_search_dir: ~
 qualys_agent::log_dest_type: file
 qualys_agent::log_file_dir: /var/log/qualys
 qualys_agent::log_level: 3
 qualys_agent::manage_group: true
+qualys_agent::manage_package: true
 qualys_agent::manage_service: true
 qualys_agent::manage_user: true
+qualys_agent::package_ensure: installed
 qualys_agent::package_name: qualys-cloud-agent
 qualys_agent::process_priority: 0
 qualys_agent::request_timeout: 600
@@ -24,5 +28,4 @@ qualys_agent::sudo_command: sudo
 qualys_agent::sudo_user: root
 qualys_agent::use_audit_dispatcher: 1
 qualys_agent::use_sudo: 0
-qualys_agent::user_group: root
-qualys_agent::version: ~
+qualys_agent::user_group: ~

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,17 +5,22 @@
 #
 class qualys_agent::config {
 
-  if $qualys_agent::log_dest_type == 'file' {
+  if $::qualys_agent::log_dest_type == 'file' {
     $channel_name = 'c3'
   } else {
     $channel_name = 'c2'
   }
 
-  if $qualys_agent::ensure == 'present' {
+  if $::qualys_agent::ensure == 'present' {
     $ensure = 'file'
   } else {
-    $ensure = $qualys_agent::ensure
+    $ensure = $::qualys_agent::ensure
   }
+
+  $requires = [
+    $::qualys_agent::package::package_dep,
+    $::qualys_agent::user::user_dep,
+  ]
 
   file { 'qualys_config':
     ensure    => $ensure,
@@ -24,26 +29,64 @@ class qualys_agent::config {
       cmd_max_timeout      => $::qualys_agent::cmd_max_timeout,
       cmd_stdout_size      => $::qualys_agent::cmd_stdout_size,
       customer_id          => $::qualys_agent::customer_id,
+      hostid_search_dir    => $::qualys_agent::hostid_search_dir,
       log_file_dir         => $::qualys_agent::log_file_dir,
       log_level            => $::qualys_agent::log_level,
       process_priority     => $::qualys_agent::process_priority,
       request_timeout      => $::qualys_agent::request_timeout,
       sudo_command         => $::qualys_agent::sudo_command,
+      sudo_user            => $::qualys_agent::sudo_user,
       use_audit_dispatcher => $::qualys_agent::use_audit_dispatcher,
       use_sudo             => $::qualys_agent::use_sudo,
       user                 => $::qualys_agent::agent_user,
       user_group           => $::qualys_agent::user_group,
     }),
-    group     => $::qualys_agent::agent_group,
+    group     => $::qualys_agent::group,
     mode      => '0600',
-    name      => "${qualys_agent::conf_dir}/qualys-cloud-agent.conf",
+    name      => "${::qualys_agent::conf_dir}/qualys-cloud-agent.conf",
     owner     => $::qualys_agent::owner,
     show_diff => true,
-    notify    => Service['qualys_agent'],
-    require   => [
-      Package['qualys_agent'],
-      User['qualys_user'],
-    ],
+    notify    => $::qualys_agent::service::service_dep,
+    require   => $requires,
+  }
+
+  # For some reason, a .properties file needs to exist on first start, so create it here
+  # and keep it present, but don't restart the service if it changes.  Just restart if the
+  # *actual* config changes.
+  file { 'qualys_properties':
+    ensure    => $ensure,
+    content   => epp('qualys_agent/qualys-cloud-agent.conf.epp', {
+      activation_id        => $::qualys_agent::activation_id,
+      cmd_max_timeout      => $::qualys_agent::cmd_max_timeout,
+      cmd_stdout_size      => $::qualys_agent::cmd_stdout_size,
+      customer_id          => $::qualys_agent::customer_id,
+      hostid_search_dir    => $::qualys_agent::hostid_search_dir,
+      log_file_dir         => $::qualys_agent::log_file_dir,
+      log_level            => $::qualys_agent::log_level,
+      process_priority     => $::qualys_agent::process_priority,
+      request_timeout      => $::qualys_agent::request_timeout,
+      sudo_command         => $::qualys_agent::sudo_command,
+      sudo_user            => $::qualys_agent::sudo_user,
+      use_audit_dispatcher => $::qualys_agent::use_audit_dispatcher,
+      use_sudo             => $::qualys_agent::use_sudo,
+      user                 => $::qualys_agent::agent_user,
+      user_group           => $::qualys_agent::user_group,
+    }),
+    group     => $::qualys_agent::group,
+    mode      => '0600',
+    name      => "${::qualys_agent::conf_dir}/qualys-cloud-agent.properties",
+    owner     => $::qualys_agent::owner,
+    show_diff => true,
+    require   => $requires,
+  }
+
+  file {  'qualys_hostid':
+    ensure  => $ensure,
+    group   => $::qualys_agent::agent_group,
+    mode    => '0660',
+    name    => $::qualys_agent::hostid_path,
+    owner   => $::qualys_agent::owner,
+    require => $requires,
   }
 
   include qualys_agent::config::qagent_log

--- a/manifests/config/qagent_log.pp
+++ b/manifests/config/qagent_log.pp
@@ -13,12 +13,8 @@ class qualys_agent::config::qagent_log {
     mode    => '0600',
     name    => "${qualys_agent::conf_dir}/qagent-log.conf",
     owner   => $::qualys_agent::owner,
-    notify    => Service['qualys_agent'],
-    require   => [
-      Package['qualys_agent'],
-      User['qualys_user'],
-    ],
-
+    notify  => $::qualys_agent::service::service_dep,
+    require => $::qualys_agent::config::requires,
   }
 
 }

--- a/manifests/config/qagent_udc_log.pp
+++ b/manifests/config/qagent_udc_log.pp
@@ -13,11 +13,8 @@ class qualys_agent::config::qagent_udc_log {
     mode    => '0600',
     name    => "${qualys_agent::conf_dir}/qagent-udc-log.conf",
     owner   => $::qualys_agent::owner,
-    notify    => Service['qualys_agent'],
-    require   => [
-      Package['qualys_agent'],
-      User['qualys_user'],
-    ],
+    notify  => $::qualys_agent::service::service_dep,
+    require => $::qualys_agent::config::requires,
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,6 +30,12 @@
 # * `customer_id`
 # The Customer ID you receive from Qualys for reporting back to their API (required)
 #
+# * `hostid_path`
+# The full filesystem path to the hostid file (Default: /etc/qualys/hostid)
+#
+# * `hostid_search_dir`
+# The HostIdSearchDir value in qualys-cloud-agent.conf (Default: undef)
+#
 # * `log_dest_type`
 # The log type (file or syslog) (Default: file)
 #
@@ -39,6 +45,22 @@
 #
 # * `log_level`
 # The LogLevel value in qualys-cloud-agent.conf (Default: 3)
+#
+# * `manage_group`
+# Boolean to determine whether the group is managed by Puppet or not (Default: true)
+#
+# * `manage_package`
+# Boolean to determine whether the package is managed by Puppet or not (Default: true)
+#
+# * `manage_service`
+# Boolean to determine whether the service is managed by Puppet or not (Default: true)
+#
+# * `manage_user`
+# Boolean to determine whether the user is managed by Puppet or not (Default: true)
+#
+# * `package_ensure`
+# The "ensure" value for the Qualys agent package. This value can be "installed", "absent",
+# or a version number if you want to specify a specific package version numer. (Default: installed)
 #
 # * `package_name`
 # The name of the package to install (Default: qualys-cloud-agent)
@@ -71,10 +93,7 @@
 # The UseSudo value in qualys-cloud-agent.conf (Default: 0)
 #
 # * `user_group`
-# The UserGroup value in qualys-cloud-agent.conf (Default: root)
-#
-# * `version`
-# The version of the Qualys agent package to install (Default: undef)
+# The UserGroup value in qualys-cloud-agent.conf (Default: undef)
 #
 # Examples
 # --------
@@ -105,10 +124,13 @@ class qualys_agent (
   Integer $cmd_stdout_size,
   Stdlib::Absolutepath $conf_dir,
   String $customer_id,
+  Stdlib::Absolutepath $hostid_path,
+  Optional[Stdlib::Absolutepath] $hostid_search_dir,
   Enum['file', 'syslog'] $log_dest_type,
   Stdlib::Absolutepath $log_file_dir,
   Integer $log_level,
   Boolean $manage_group,
+  Boolean $manage_package,
   Boolean $manage_service,
   Boolean $manage_user,
   String $package_name,
@@ -122,12 +144,23 @@ class qualys_agent (
   Integer $use_audit_dispatcher,
   Integer $use_sudo,
   Optional[String] $user_group,
-  Optional[String] $version,
 ) {
 
-  # Protect against an bad setting for log_file_dir
+  # Protect against an bad setting for filesystem paths
+  if $::qualys_agent::agent_user_homedir == '/' {
+    fail('agent_user_homedir is set to /.  Installation cannot continue.')
+  }
+  if $::qualys_agent::conf_dir == '/' {
+    fail('conf_dir is set to /.  Installation cannot continue.')
+  }
+  if $::qualys_agent::hostid_path == '/' {
+    fail('hostid_path is set to /.  Installation cannot continue.')
+  }
+  if $::qualys_agent::hostid_search_dir == '/' {
+    fail('hostid_path is set to /.  Installation cannot continue.')
+  }
   if $::qualys_agent::log_file_dir == '/' {
-    fail('The log file directory is set to /.  Installation cannot continue.')
+    fail('log_file_dir is set to /.  Installation cannot continue.')
   }
 
   if $::qualys_agent::agent_user {
@@ -136,13 +169,14 @@ class qualys_agent (
     $owner = 'root'
   }
 
+  if $::qualys_agent::user_group {
+    $group = $::qualys_agent::user_group
+  } else {
+    $group = 'root'
+  }
+
   contain 'qualys_agent::user'
   contain 'qualys_agent::package'
   contain 'qualys_agent::config'
   contain 'qualys_agent::service'
-
-  Class['qualys_agent::user']
-  -> Class['qualys_agent::package']
-  -> Class['qualys_agent::config']
-  -> Class['qualys_agent::service']
 }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -4,18 +4,25 @@
 #
 class qualys_agent::package {
 
-  if $::qualys_agent::ensure == 'present' {
-    if $::qualys_agent::version {
-      $ensure = $::qualys_agent::version
-    } else {
-      $ensure = $::qualys_agent::ensure
+  if $::qualys_agent::manage_package {
+    # Force package remove if agent ensure is "absent"
+    $ensure = $::qualys_agent::ensure ? {
+      present => $::qualys_agent::package_ensure,
+      absent  => 'absent',
+    }
+
+    package { 'qualys_agent':
+      ensure => $ensure,
+      name   => $::qualys_agent::package_name,
+      notify => $::qualys_agent::service::service_dep,
+    }
+    # Do not create an ordering dependency if we are removing the agent
+    $package_dep = $::qualys_agent::ensure ? {
+      present => Package['qualys_agent'],
+      absent  => undef,
     }
   } else {
-    $ensure = $::qualys_agent::ensure
-  }
-  package { 'qualys_agent':
-    ensure => $ensure,
-    name   => $::qualys_agent::package_name,
+    $package_dep = undef
   }
 
   # Fix permissions on all paths used by the agent as the package does not do this on install
@@ -26,11 +33,13 @@ class qualys_agent::package {
     $::qualys_agent::log_file_dir,
   ]
 
-  file { $agent_paths :
-    ensure  => 'directory',
-    group   => $::qualys_agent::agent_group,
-    owner   => $::qualys_agent::owner,
-    require => User[$::qualys_agent::agent_user],
-    recurse => true,
+  if $::qualys_agent::ensure != 'absent' {
+    file { $agent_paths :
+      ensure  => 'directory',
+      group   => $::qualys_agent::agent_group,
+      owner   => $::qualys_agent::owner,
+      require => $::qualys_agent::user::user_dep,
+      recurse => true,
+    }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,16 +5,32 @@
 class qualys_agent::service {
 
   if $::qualys_agent::manage_service {
+    # Force service stopped and disabled if agent ensure is "absent"
+    $ensure = $::qualys_agent::ensure ? {
+      present => $::qualys_agent::service_ensure,
+      absent  => 'stopped',
+    }
+    $enable = $::qualys_agent::ensure ? {
+      present => $::qualys_agent::service_enable,
+      absent  => false,
+    }
+
     service { 'qualys_agent':
-      ensure  => $::qualys_agent::service_ensure,
-      enable  => $::qualys_agent::service_enable,
-      name    => $::qualys_agent::service_name,
-      require => [
-        Package['qualys_agent'],
+      ensure    => $ensure,
+      enable    => $enable,
+      name      => $::qualys_agent::service_name,
+      require   => [
         File['qualys_config'],
         File['qualys_log_config'],
         File['qualys_udc_log_config'],
       ],
+      subscribe => $::qualys_agent::package::package_dep,
+    }
+
+    # Do not create an ordering dependency if we are removing the agent
+    $service_dep = $::qualys_agent::ensure ? {
+      present => Service['qualys_agent'],
+      absent  => undef,
     }
   }
 }

--- a/templates/qualys-cloud-agent.conf.epp
+++ b/templates/qualys-cloud-agent.conf.epp
@@ -2,6 +2,7 @@
       Integer $cmd_max_timeout,
       Integer $cmd_stdout_size,
       String $customer_id,
+      Optional[Stdlib::Absolutepath] $hostid_search_dir,
       Stdlib::Absolutepath $log_file_dir,
       Integer $log_level,
       Integer $process_priority,
@@ -27,6 +28,9 @@ ActivationId=<%= $activation_id %>
 CmdMaxTimeOut=<%= $cmd_max_timeout %>
 CmdStdOutSize=<%= $cmd_stdout_size %>
 CustomerId=<%= $customer_id %>
+<% if $hostid_search_dir { -%>
+HostIdSearchDir=<%= $hostid_search_dir %>
+<% } -%>
 LogFileDir=<%= $log_file_dir %>
 LogLevel=<%= $log_level %>
 ProcessPriority=<%= $process_priority %>

--- a/vagrant_files/centos7-p5.sh
+++ b/vagrant_files/centos7-p5.sh
@@ -7,4 +7,6 @@ cd /etc/puppetlabs/code/modules/qualys_agent || exit
 rm -f Gemfile.lock
 rm -f Puppetfile.lock
 bundle install
-librarian-puppet install --verbose --path=/etc/puppetlabs/code/modules
+# librarian-puppet is busted in some way...
+# librarian-puppet install --verbose --path=/etc/puppetlabs/code/modules
+puppet module install puppetlabs-stdlib


### PR DESCRIPTION
* Add License file
* Fix up the README
* Fix default user_group to match default from the package
* Add a qualys-cloud-agent.properties file as it seems to be necessary for first-start
* Guard against doing anything to root user/group
* Fix how dependencies are handled across all classes
* Syntax bug fix in `user.pp`
* Add hostid settings
* Add booleans for manage_package and package_ensure
* Manage existence and permissions on hostid file, but not contents
* Fix the vagrant install script to work around the librarian-puppet problem