### PR TITLE
Allow permissions to be set differently on Qualys logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,6 @@ workflows:
           ruby_version: '2.4.6'
           puppet_version: '< 6.0.0'
       - puppet/run-tests:
-          name: 'puppet-5-ruby-2.5.5'
-          ruby_version: '2.5.5'
-          puppet_version: '< 6.0.0'
-      - puppet/run-tests:
           name: 'puppet-6-ruby-2.3.8'
           ruby_version: '2.3.8'
           puppet_version: '< 7.0.0'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.1
+    rev: v2.5.0
     hooks:
       - id: trailing-whitespace
       - id: check-executables-have-shebangs
@@ -12,7 +12,7 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
   - repo: https://github.com/chriskuehl/puppet-pre-commit-hooks.git
-    rev: v2.0.2
+    rev: v2.1.0
     hooks:
       - id: puppet-validate
       - id: erb-validate
@@ -21,6 +21,6 @@ repos:
         args:
           - --fail-on-warnings
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.15.0
+    rev: v1.23.0
     hooks:
       - id: yamllint

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 ---
-require: rubocop-rspec
+require:
+- rubocop-rspec
+- rubocop-i18n
 AllCops:
   DisplayCopNames: true
   TargetRubyVersion: '2.1'
@@ -19,10 +21,13 @@ AllCops:
 Metrics/LineLength:
   Description: People have wide screens, use them.
   Max: 200
+GetText:
+  Enabled: false
 GetText/DecorateString:
   Description: We don't want to decorate test output.
   Exclude:
-  - spec/*
+  - spec/**/*
+  Enabled: false
 RSpec/BeforeAfterAll:
   Description: Beware of using after(:all) as it may cause state to leak between tests.
     A necessary evil in acceptance testing.
@@ -84,6 +89,12 @@ Style/MethodCalledOnDoEndBlock:
   Enabled: true
 Style/StringMethods:
   Enabled: true
+GetText/DecorateFunctionMessage:
+  Enabled: false
+GetText/DecorateStringFormattingUsingInterpolation:
+  Enabled: false
+GetText/DecorateStringFormattingUsingPercent:
+  Enabled: false
 Layout/EndOfLine:
   Enabled: false
 Layout/IndentHeredoc:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "jpogran.puppet-vscode",
+    "rebornix.Ruby"
+  ]
+}

--- a/Gemfile
+++ b/Gemfile
@@ -17,17 +17,18 @@ ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
 minor_version = ruby_version_segments[0..1].join('.')
 
 group :development do
-  gem "fast_gettext", '1.1.0',                         require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
-  gem "fast_gettext",                                  require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
-  gem "json_pure", '<= 2.0.1',                         require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
-  gem "json", '= 1.8.1',                               require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
-  gem "json", '= 2.0.4',                               require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.1.0',                               require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "puppet-module-posix-default-r#{minor_version}", require: false, platforms: [:ruby]
-  gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby]
-  gem "puppet-module-win-default-r#{minor_version}",   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-win-dev-r#{minor_version}",       require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "github_changelog_generator",                    require: false, git: 'https://github.com/skywinder/github-changelog-generator', ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')
+  gem "fast_gettext", '1.1.0',                                   require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
+  gem "fast_gettext",                                            require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
+  gem "json_pure", '<= 2.0.1',                                   require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
+  gem "json", '= 1.8.1',                                         require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
+  gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "rb-readline", '= 0.5.5',                                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet-module-posix-default-r#{minor_version}", '~> 0.4', require: false, platforms: [:ruby]
+  gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.4',     require: false, platforms: [:ruby]
+  gem "puppet-module-win-default-r#{minor_version}", '~> 0.4',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet-module-win-dev-r#{minor_version}", '~> 0.4',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "github_changelog_generator",                              require: false, git: 'https://github.com/skywinder/github-changelog-generator', ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+require 'puppet_litmus/rake_tasks' if Bundler.rubygems.find_name('puppet_litmus').any?
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-syntax/tasks/puppet-syntax'
 require 'puppet_blacksmith/rake_tasks' if Bundler.rubygems.find_name('puppet-blacksmith').any?
@@ -15,8 +18,17 @@ end
 
 def changelog_project
   return unless Rake.application.top_level_tasks.include? "changelog"
-  returnVal = "puppet-qualys_agent" || JSON.load(File.read('metadata.json'))['name']
-  raise "unable to find the changelog_project in .sync.yml or the name in metadata.json" if returnVal.nil?
+
+  returnVal = "puppet-qualys_agent"
+  returnVal ||= begin
+    metadata_source = JSON.load(File.read('metadata.json'))['source']
+    metadata_source_match = metadata_source && metadata_source.match(%r{.*\/([^\/]*?)(?:\.git)?\Z})
+
+    metadata_source_match && metadata_source_match[1]
+  end
+
+  raise "unable to find the changelog_project in .sync.yml or calculate it from the source in metadata.json" if returnVal.nil?
+
   puts "GitHubChangelogGenerator project:#{returnVal}"
   returnVal
 end

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -12,7 +12,10 @@ qualys_agent::hostid_path: /etc/qualys/hostid
 qualys_agent::hostid_search_dir: ~
 qualys_agent::log_dest_type: file
 qualys_agent::log_file_dir: /var/log/qualys
+qualys_agent::log_group: ~
 qualys_agent::log_level: 3
+qualys_agent::log_mode: '0600'
+qualys_agent::log_owner: ~
 qualys_agent::manage_group: true
 qualys_agent::manage_package: true
 qualys_agent::manage_service: true

--- a/manifests/config/qagent_log.pp
+++ b/manifests/config/qagent_log.pp
@@ -1,6 +1,7 @@
-# @summary Configure the Qualys agent
+# Class: qualys_agent::config::qagent_log
 #
 # Manage the main qagent-log.conf configuration file
+#
 class qualys_agent::config::qagent_log {
 
   file { 'qualys_log_config':
@@ -16,4 +17,13 @@ class qualys_agent::config::qagent_log {
     require => $qualys_agent::config::requires,
   }
 
+  if $qualys_agent::ensure != 'absent' {
+    file { "${qualys_agent::log_file_dir}/qualys-cloud-agent.log" :
+      ensure  => $qualys_agent::config::ensure,
+      group   => $qualys_agent::log_group_final,
+      mode    => $qualys_agent::log_mode,
+      owner   => $qualys_agent::log_owner_final,
+      require => File[$qualys_agent::log_file_dir],
+    }
+  }
 }

--- a/manifests/config/qagent_udc_log.pp
+++ b/manifests/config/qagent_udc_log.pp
@@ -1,6 +1,7 @@
-# @summary Configure the Qualys agent
+# Class: qualys_agent::config::qagent_udc_log
 #
 # Manage the main qagent-udc-log.conf configuration file
+#
 class qualys_agent::config::qagent_udc_log {
 
   file { 'qualys_udc_log_config':
@@ -16,4 +17,13 @@ class qualys_agent::config::qagent_udc_log {
     require => $qualys_agent::config::requires,
   }
 
+  if $qualys_agent::ensure != 'absent' {
+    file { "${qualys_agent::log_file_dir}/qualys-udc-scan.log" :
+      ensure  => $qualys_agent::config::ensure,
+      group   => $qualys_agent::log_group_final,
+      mode    => $qualys_agent::log_mode,
+      owner   => $qualys_agent::log_owner_final,
+      require => File[$qualys_agent::log_file_dir],
+    }
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,8 +43,17 @@
 # The LogFileDir value in qualys-cloud-agent.conf
 # The directory in which the log files should be written (Default: /var/log/qualys)
 #
+# * `log_group`
+# The group that should own files in the log directory (Default: $agent_group)
+#
 # * `log_level`
 # The LogLevel value in qualys-cloud-agent.conf (Default: 3)
+#
+# * `log_mode`
+# The file mode for log files in $log_file_dir (Default: 0600)
+#
+# * `log_owner`
+# The user that should own files in the log directory (Default: $agent_user)
 #
 # * `manage_group`
 # Boolean to determine whether the group is managed by Puppet or not (Default: true)
@@ -125,7 +134,10 @@ class qualys_agent (
   Optional[Stdlib::Absolutepath] $hostid_search_dir,
   Enum['file', 'syslog'] $log_dest_type,
   Stdlib::Absolutepath $log_file_dir,
+  Optional[String] $log_group,
   Integer $log_level,
+  String $log_mode,
+  Optional[String] $log_owner,
   Boolean $manage_group,
   Boolean $manage_package,
   Boolean $manage_service,
@@ -160,16 +172,28 @@ class qualys_agent (
     fail('log_file_dir is set to /.  Installation cannot continue.')
   }
 
+  if $qualys_agent::agent_group {
+    $group = $qualys_agent::agent_group
+  } else {
+    $group = 'root'
+  }
+
   if $qualys_agent::agent_user {
     $owner = $qualys_agent::agent_user
   } else {
     $owner = 'root'
   }
 
-  if $qualys_agent::agent_group {
-    $group = $qualys_agent::agent_group
+  if $qualys_agent::log_group {
+    $log_group_final = $qualys_agent::log_group
   } else {
-    $group = 'root'
+    $log_group_final = $group
+  }
+
+  if $qualys_agent::log_owner {
+    $log_owner_final = $qualys_agent::log_owner
+  } else {
+    $log_owner_final = $owner
   }
 
   contain 'qualys_agent::user'

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -29,7 +29,6 @@ class qualys_agent::package {
     '/usr/local/qualys',
     '/etc/qualys',
     '/var/spool/qualys',
-    $qualys_agent::log_file_dir,
   ]
 
   if $qualys_agent::ensure != 'absent' {
@@ -39,6 +38,13 @@ class qualys_agent::package {
       owner   => $qualys_agent::owner,
       require => [$package_dep, $qualys_agent::user::user_dep, $qualys_agent::user::group_dep],
       recurse => true,
+    }
+    file { $qualys_agent::log_file_dir :
+      ensure  => 'directory',
+      group   => $qualys_agent::log_group_final,
+      owner   => $qualys_agent::log_owner_final,
+      require => $package_dep,
+      recurse => false,
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "broadinstitute-qualys_agent",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "author": "Andrew Teixeira <teixeira@broadinstitute.org>",
   "summary": "Install and configure the Qualys Cloud Agent",
   "license": "BSD-3-Clause",
@@ -18,28 +18,24 @@
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "6",
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
@@ -63,7 +59,7 @@
       "version_requirement": ">= 4.10.0 < 7.0.0"
     }
   ],
-  "pdk-version": "1.11.1",
-  "template-url": "https://github.com/puppetlabs/pdk-templates#1.10.0",
-  "template-ref": "1.10.0-0-gbba9ac3"
+  "pdk-version": "1.17.0",
+  "template-url": "https://github.com/puppetlabs/pdk-templates#1.17.0",
+  "template-ref": "tags/1.17.0-0-gd3a4319"
 }

--- a/spec/classes/qualys_agent_spec.rb
+++ b/spec/classes/qualys_agent_spec.rb
@@ -20,7 +20,7 @@ describe 'qualys_agent' do
       context 'with correct activation_id and customer_id' do
         let(:environment) { 'unittest' }
 
-        dirnames = ['/usr/local/qualys', '/etc/qualys', '/var/spool/qualys', '/var/log/qualys']
+        dirnames = ['/usr/local/qualys', '/etc/qualys', '/var/spool/qualys']
 
         context 'with default values for all parameters' do
           it do
@@ -148,6 +148,34 @@ UseSudo=0}
               .with(ensure: 'installed', name: 'qualys-cloud-agent')
           end
 
+          it do
+            is_expected.to contain_file('/var/log/qualys').with(
+              ensure: 'directory',
+              group: 'root',
+              owner: 'root',
+              recurse: false,
+              require: 'Package[qualys_agent]',
+            )
+          end
+          it do
+            is_expected.to contain_file('/var/log/qualys/qualys-cloud-agent.log').with(
+              ensure: 'file',
+              group: 'root',
+              mode: '0600',
+              owner: 'root',
+              require: 'File[/var/log/qualys]',
+            )
+          end
+          it do
+            is_expected.to contain_file('/var/log/qualys/qualys-udc-scan.log').with(
+              ensure: 'file',
+              group: 'root',
+              mode: '0600',
+              owner: 'root',
+              require: 'File[/var/log/qualys]',
+            )
+          end
+
           dirnames.each do |directory|
             it do
               is_expected.to contain_file(directory).with(
@@ -253,6 +281,19 @@ UseSudo=0}
             )
           end
 
+          it do
+            is_expected.to contain_file('/var/log/qualys').with(
+              group: 'newgrp',
+              require: 'Package[qualys_agent]',
+            )
+          end
+          it do
+            is_expected.to contain_file('/var/log/qualys/qualys-cloud-agent.log').with(group: 'newgrp')
+          end
+          it do
+            is_expected.to contain_file('/var/log/qualys/qualys-udc-scan.log').with(group: 'newgrp')
+          end
+
           dirnames.each do |directory|
             it do
               is_expected.to contain_file(directory).with(
@@ -312,6 +353,19 @@ UseSudo=0}
               system: true,
               require: nil,
             )
+          end
+
+          it do
+            is_expected.to contain_file('/var/log/qualys').with(
+              owner: 'newuser',
+              require: 'Package[qualys_agent]',
+            )
+          end
+          it do
+            is_expected.to contain_file('/var/log/qualys/qualys-cloud-agent.log').with(owner: 'newuser')
+          end
+          it do
+            is_expected.to contain_file('/var/log/qualys/qualys-udc-scan.log').with(owner: 'newuser')
           end
 
           dirnames.each do |directory|
@@ -382,6 +436,26 @@ UseSudo=0}
               password: '*',
               system: true,
               require: 'Group[qualys_group]',
+            )
+          end
+
+          it do
+            is_expected.to contain_file('/var/log/qualys').with(
+              group: 'newgrp',
+              owner: 'newuser',
+              require: 'Package[qualys_agent]',
+            )
+          end
+          it do
+            is_expected.to contain_file('/var/log/qualys/qualys-cloud-agent.log').with(
+              group: 'newgrp',
+              owner: 'newuser',
+            )
+          end
+          it do
+            is_expected.to contain_file('/var/log/qualys/qualys-udc-scan.log').with(
+              group: 'newgrp',
+              owner: 'newuser',
             )
           end
 
@@ -579,6 +653,19 @@ UseSudo=1}
             is_expected.not_to contain_group('qualys_group')
           end
 
+          it do
+            is_expected.to contain_file('/var/log/qualys').with(
+              group: 'newgrp',
+              require: 'Package[qualys_agent]',
+            )
+          end
+          it do
+            is_expected.to contain_file('/var/log/qualys/qualys-cloud-agent.log').with(group: 'newgrp')
+          end
+          it do
+            is_expected.to contain_file('/var/log/qualys/qualys-udc-scan.log').with(group: 'newgrp')
+          end
+
           dirnames.each do |directory|
             it do
               is_expected.to contain_file(directory).with(group: 'newgrp', require: ['Package[qualys_agent]'])
@@ -619,6 +706,16 @@ UseSudo=1}
 
           it do
             is_expected.not_to contain_package('qualys_agent')
+          end
+
+          it do
+            is_expected.to contain_file('/var/log/qualys').with(require: nil)
+          end
+          it do
+            is_expected.to contain_file('/var/log/qualys/qualys-cloud-agent.log')
+          end
+          it do
+            is_expected.to contain_file('/var/log/qualys/qualys-udc-scan.log')
           end
 
           dirnames.each do |directory|
@@ -671,6 +768,16 @@ UseSudo=1}
             is_expected.not_to contain_user('qualys_user')
           end
 
+          it do
+            is_expected.to contain_file('/var/log/qualys').with(owner: 'newuser', require: 'Package[qualys_agent]')
+          end
+          it do
+            is_expected.to contain_file('/var/log/qualys/qualys-cloud-agent.log').with(owner: 'newuser')
+          end
+          it do
+            is_expected.to contain_file('/var/log/qualys/qualys-udc-scan.log').with(owner: 'newuser')
+          end
+
           dirnames.each do |directory|
             it do
               is_expected.to contain_file(directory).with(owner: 'newuser', require: ['Package[qualys_agent]'])
@@ -701,6 +808,93 @@ UseSudo=1}
               owner: 'newuser',
               require: ['Package[qualys_agent]'],
             )
+          end
+        end
+
+        context 'log_group set to "newgroup"' do
+          let(:params) do
+            { log_group: 'newgroup' }
+          end
+
+          it do
+            is_expected.to contain_file('/var/log/qualys').with(group: 'newgroup')
+          end
+          it do
+            is_expected.to contain_file('/var/log/qualys/qualys-cloud-agent.log').with(group: 'newgroup')
+          end
+          it do
+            is_expected.to contain_file('/var/log/qualys/qualys-udc-scan.log').with(group: 'newgroup')
+          end
+
+          dirnames.each do |directory|
+            it do
+              is_expected.to contain_file(directory).with(group: 'root')
+            end
+          end
+          it do
+            is_expected.to contain_file('qualys_config').with(group: 'root')
+          end
+          it do
+            is_expected.to contain_file('qualys_properties').with(group: 'root')
+          end
+          it do
+            is_expected.to contain_file('qualys_hostid').with(group: 'root')
+          end
+          it do
+            is_expected.to contain_file('qualys_log_config').with(group: 'root')
+          end
+          it do
+            is_expected.to contain_file('qualys_udc_log_config').with(group: 'root')
+          end
+        end
+
+        context 'log_owner set to "newuser"' do
+          let(:params) do
+            { log_owner: 'newuser' }
+          end
+
+          it do
+            is_expected.to contain_file('/var/log/qualys').with(owner: 'newuser')
+          end
+          it do
+            is_expected.to contain_file('/var/log/qualys/qualys-cloud-agent.log').with(owner: 'newuser')
+          end
+          it do
+            is_expected.to contain_file('/var/log/qualys/qualys-udc-scan.log').with(owner: 'newuser')
+          end
+
+          dirnames.each do |directory|
+            it do
+              is_expected.to contain_file(directory).with(owner: 'root')
+            end
+          end
+          it do
+            is_expected.to contain_file('qualys_config').with(owner: 'root')
+          end
+          it do
+            is_expected.to contain_file('qualys_properties').with(owner: 'root')
+          end
+          it do
+            is_expected.to contain_file('qualys_hostid').with(owner: 'root')
+          end
+          it do
+            is_expected.to contain_file('qualys_log_config').with(owner: 'root')
+          end
+          it do
+            is_expected.to contain_file('qualys_udc_log_config').with(owner: 'root')
+          end
+        end
+
+        context 'log file mode set to 0644' do
+          let(:params) do
+            { log_mode: '0644' }
+          end
+
+          it do
+            is_expected.to contain_file('/var/log/qualys/qualys-cloud-agent.log').with(mode: '0644')
+          end
+          it do
+            is_expected.to contain_file('/var/log/qualys/qualys-udc-scan.log').with(mode: '0644')
           end
         end
 
@@ -758,7 +952,17 @@ UseSudo=1}
             is_expected.to contain_package('qualys_agent').with(ensure: 'absent')
           end
 
-          # Will not remove these directories as they are part of the package
+          # Will not manage these files/directories when "absent"
+          it do
+            is_expected.not_to contain_file('/var/log/qualys')
+          end
+          it do
+            is_expected.not_to contain_file('/var/log/qualys/qualys-cloud-agent.log')
+          end
+          it do
+            is_expected.not_to contain_file('/var/log/qualys/qualys-udc-scan.log')
+          end
+
           dirnames.each do |directory|
             it do
               is_expected.not_to contain_file(directory)

--- a/spec/fixtures/hieradata/environments/unittest-mode.yaml
+++ b/spec/fixtures/hieradata/environments/unittest-mode.yaml
@@ -1,0 +1,5 @@
+---
+qualys_agent::activation_id: 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX'
+qualys_agent::customer_id: 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX'
+qualys_agent::config::qagent_udc_log::mode: '0644'
+qualys_agent::config::qagent_log::mode: '0644'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
 
@@ -25,6 +27,11 @@ default_fact_files.each do |f|
   end
 end
 
+# read default_facts and merge them over what is provided by facterdb
+default_facts.each do |fact, value|
+  add_custom_fact fact, value
+end
+
 RSpec.configure do |c|
   c.default_facts = default_facts
   c.hiera_config = 'spec/fixtures/hiera.yaml'
@@ -38,6 +45,8 @@ RSpec.configure do |c|
   end
 end
 
+# Ensures that a module is defined
+# @param module_name Name of the module
 def ensure_module_defined(module_name)
   module_name.split('::').reduce(Object) do |last_module, next_module|
     last_module.const_set(next_module, Module.new) unless last_module.const_defined?(next_module, false)


### PR DESCRIPTION
* Allow permissions to be set differently on Qualys logs
* PDK updates
* SPEC updates
* `metadata.json` version updates
* Ruby version updates for CircleCI
* pre-commit config update