### PR TITLE
Allow Sensitive value type, disallow empty ID's

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,14 +119,14 @@
 #
 class qualys_agent (
   Enum['absent', 'present'] $ensure,
-  String $activation_id,
+  Variant[String[1], Sensitive[String[1]]] $activation_id,
   Optional[String] $agent_group,
   Optional[String] $agent_user,
   Stdlib::Absolutepath $agent_user_homedir,
   Integer $cmd_max_timeout,
   Integer $cmd_stdout_size,
   Stdlib::Absolutepath $conf_dir,
-  String $customer_id,
+  Variant[String[1], Sensitive[String[1]]] $customer_id,
   Stdlib::Absolutepath $env_dir,
   Stdlib::Absolutepath $hostid_path,
   Optional[Stdlib::Absolutepath] $hostid_search_dir,

--- a/templates/qualys-cloud-agent.conf.epp
+++ b/templates/qualys-cloud-agent.conf.epp
@@ -1,7 +1,7 @@
-<%- | String $activation_id,
+<%- | Variant[String[1], Sensitive[String[1]]] $activation_id,
       Integer $cmd_max_timeout,
       Integer $cmd_stdout_size,
-      String $customer_id,
+      Variant[String[1], Sensitive[String[1]]] $customer_id,
       Optional[String] $webservice_uri,
       Optional[Stdlib::Absolutepath] $hostid_search_dir,
       Stdlib::Absolutepath $log_file_dir,
@@ -25,10 +25,10 @@
 #RequestTimeOut: Http request timeout in seconds.
 #CmdStdOutSize: Command std output size in KB. Any command output size exceeds this time will be truncated.
 
-ActivationId=<%= $activation_id %>
+ActivationId=<%= unwrap($activation_id) %>
 CmdMaxTimeOut=<%= $cmd_max_timeout %>
 CmdStdOutSize=<%= $cmd_stdout_size %>
-CustomerId=<%= $customer_id %>
+CustomerId=<%= unwrap($customer_id) %>
 <% if $hostid_search_dir { -%>
 HostIdSearchDir=<%= $hostid_search_dir %>
 <% } -%>


### PR DESCRIPTION
This allows the activation_id and customer_id to utilize the Sensitive data type instead of only a plain string. It also sets a minimum string length of 1 so that empty strings are not allowed.